### PR TITLE
connections: Wait for output.

### DIFF
--- a/pybricksdev/connections.py
+++ b/pybricksdev/connections.py
@@ -760,3 +760,4 @@ class PybricksHub:
 
         if wait:
             await self.user_program_stopped.wait()
+            await asyncio.sleep(0.3)


### PR DESCRIPTION
The user program stopped signal can come in sooner than the last piece of output, so give it some extra time.